### PR TITLE
Use ArrayView2 instead of Array2 everywhere

### DIFF
--- a/src/binary_segmentation.rs
+++ b/src/binary_segmentation.rs
@@ -17,7 +17,7 @@ pub struct BinarySegmentationTree {
 
 #[allow(dead_code)]
 impl BinarySegmentationTree {
-    pub fn new(X: &ndarray::Array2<f64>, control: Control) -> BinarySegmentationTree {
+    pub fn new(X: &ndarray::ArrayView2<'_, f64>, control: Control) -> BinarySegmentationTree {
         BinarySegmentationTree {
             start: 0,
             stop: X.nrows(),
@@ -105,15 +105,16 @@ mod tests {
     #[test]
     fn test_binary_segmentation_change_in_mean() {
         let X = testing::array();
+        let X_view = X.view();
 
-        assert_eq!(X.shape(), &[100, 5]);
+        assert_eq!(X_view.shape(), &[100, 5]);
 
         let control = Control {
             minimal_gain_to_split: 0.1,
             minimal_relative_segment_length: 0.1,
         };
-        let mut optimizer = testing::ChangeInMean::new(&X);
-        let mut binary_segmentation = BinarySegmentationTree::new(&X, control);
+        let mut optimizer = testing::ChangeInMean::new(&X_view);
+        let mut binary_segmentation = BinarySegmentationTree::new(&X_view, control);
 
         binary_segmentation.grow(&mut optimizer);
 

--- a/src/change_in_mean.rs
+++ b/src/change_in_mean.rs
@@ -3,13 +3,13 @@ use super::model_selection::ModelSelection;
 use super::optimizer::Optimizer;
 
 pub struct ChangeInMean<'a> {
-    X: &'a ndarray::Array2<f64>,
+    X: &'a ndarray::ArrayView2<'a, f64>,
     X_cumsum: Option<ndarray::Array2<f64>>,
 }
 
 impl<'a> ChangeInMean<'a> {
-    #[allow(dead_code)] // TODO Get rid of this.
-    pub fn new(X: &'a ndarray::Array2<f64>) -> ChangeInMean<'a> {
+    #[allow(dead_code)]
+    pub fn new(X: &'a ndarray::ArrayView2<'a, f64>) -> ChangeInMean<'a> {
         ChangeInMean {
             X,
             X_cumsum: Option::None,
@@ -70,7 +70,9 @@ mod tests {
     #[test]
     fn test_X_cumsum() {
         let X = ndarray::array![[1., 0.], [1., 0.], [1., 1.], [1., 1.]];
-        let mut change_in_mean = ChangeInMean::new(&X);
+        let X_view = X.view();
+
+        let mut change_in_mean = ChangeInMean::new(&X_view);
         change_in_mean.calculate_cumsum();
 
         let expected = ndarray::array![[0., 0.], [1., 0.], [2., 0.], [3., 1.], [4., 2.]];
@@ -83,11 +85,12 @@ mod tests {
     #[case(12, 16)]
     fn test_smart_change_in_mean_gain(#[case] start: usize, #[case] stop: usize) {
         let X = testing::array();
+        let X_view = X.view();
 
-        assert_eq!(X.shape(), &[100, 5]);
+        assert_eq!(X_view.shape(), &[100, 5]);
 
-        let mut change_in_mean = ChangeInMean::new(&X);
-        let mut simple_change_in_mean = testing::ChangeInMean::new(&X);
+        let mut change_in_mean = ChangeInMean::new(&X_view);
+        let mut simple_change_in_mean = testing::ChangeInMean::new(&X_view);
 
         for split in start..stop {
             assert_approx_eq!(

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -54,9 +54,11 @@ mod tests {
     #[case(3, 3, 0.)]
     fn test_change_in_mean_loss(#[case] start: usize, #[case] stop: usize, #[case] expected: f64) {
         let X = ndarray::array![[0., 0.], [0., 0.], [0., 1.], [0., 1.]];
+        let X_view = X.view();
+
         assert_eq!(X.shape(), &[4, 2]);
 
-        let change_in_mean = testing::ChangeInMean::new(&X);
+        let change_in_mean = testing::ChangeInMean::new(&X_view);
         assert_approx_eq!(change_in_mean.loss(start, stop), expected);
     }
 
@@ -80,9 +82,10 @@ mod tests {
         #[case] expected: f64,
     ) {
         let X = ndarray::array![[1., 0.], [1., 0.], [1., 1.], [1., 1.], [0., -1.], [1., 0.]];
-        assert_eq!(X.shape(), &[6, 2]);
+        let X_view = X.view();
+        assert_eq!(X_view.shape(), &[6, 2]);
 
-        let mut change_in_mean = testing::ChangeInMean::new(&X);
+        let mut change_in_mean = testing::ChangeInMean::new(&X_view);
         assert_approx_eq!(change_in_mean.gain(start, stop, split), expected);
         assert_approx_eq!(
             change_in_mean.gain_full(start, stop, vec![split])[split],

--- a/src/model_selection.rs
+++ b/src/model_selection.rs
@@ -43,9 +43,10 @@ mod tests {
             [-1., -1.],
             [-1., -1.]
         ];
+        let X_view = X.view();
         assert_eq!(X.shape(), &[7, 2]);
 
-        let mut change_in_mean = testing::ChangeInMean::new(&X);
+        let mut change_in_mean = testing::ChangeInMean::new(&X_view);
 
         assert_eq!(
             change_in_mean.is_significant(

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -55,9 +55,10 @@ mod tests {
             [-1., -1.],
             [-1., -1.]
         ];
-        assert_eq!(X.shape(), &[7, 2]);
+        let X_view = X.view();
+        assert_eq!(X_view.shape(), &[7, 2]);
 
-        let mut change_in_mean = testing::ChangeInMean::new(&X);
+        let mut change_in_mean = testing::ChangeInMean::new(&X_view);
 
         assert_eq!(
             change_in_mean.find_best_split(start, stop, start..stop),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -3,20 +3,20 @@ pub mod testing {
     use super::super::gain;
     use super::super::model_selection::ModelSelection;
     use super::super::optimizer;
-    use ndarray::{s, Array, Array2};
+    use ndarray::{s, Array, Array2, ArrayView2, Axis};
     use ndarray_rand::rand_distr::Uniform;
     use ndarray_rand::RandomExt;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
 
     pub struct ChangeInMean<'a> {
-        X: &'a ndarray::Array2<f64>,
+        X: &'a ndarray::ArrayView2<'a, f64>,
     }
 
     impl<'a> ChangeInMean<'a> {
         #[allow(dead_code)]
-        pub fn new(X: &'a ndarray::Array2<f64>) -> ChangeInMean<'a> {
-            ChangeInMean { X: &X }
+        pub fn new(X: &'a ArrayView2<'a, f64>) -> ChangeInMean<'a> {
+            ChangeInMean { X }
         }
     }
 
@@ -33,13 +33,13 @@ pub mod testing {
             let n_total = self.X.nrows() as f64;
             let n_slice = (stop - start) as f64;
 
-            let slice = &self.X.slice(ndarray::s![start..stop, ..]);
+            let slice = &self.X.slice(s![start..stop, ..]);
 
             // For 1D, the change in mean loss is equal to
             // 1 / n_total * [sum_i x_i**2 - 1/n_slice (sum_i x_i)**2]
             // For 2D, the change in mean loss is just the sum of losses for each dimension.
             let loss = slice.mapv(|a| a.powi(2)).sum()
-                - slice.sum_axis(ndarray::Axis(0)).mapv(|a| a.powi(2)).sum() / n_slice;
+                - slice.sum_axis(Axis(0)).mapv(|a| a.powi(2)).sum() / n_slice;
 
             loss / n_total
         }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,13 +3,13 @@ use crate::change_in_mean::ChangeInMean;
 use crate::control::Control;
 use ndarray;
 
-pub fn hdcd(X: ndarray::Array2<f64>) -> Vec<usize> {
+pub fn hdcd<'a>(X: &'a ndarray::ArrayView2<'a, f64>) -> Vec<usize> {
     let control = Control {
         minimal_gain_to_split: 0.1,
         minimal_relative_segment_length: 0.1,
     };
-    let mut optimizer = ChangeInMean::new(&X);
-    let mut binary_segmentation = BinarySegmentationTree::new(&X, control);
+    let mut optimizer = ChangeInMean::new(X);
+    let mut binary_segmentation = BinarySegmentationTree::new(X, control);
 
     binary_segmentation.grow(&mut optimizer);
 
@@ -27,6 +27,6 @@ mod tests {
 
         assert_eq!(X.shape(), &[100, 5]);
 
-        assert_eq!(hdcd(X), vec![25, 40, 80]);
+        assert_eq!(hdcd(&X.view()), vec![25, 40, 80]);
     }
 }


### PR DESCRIPTION
Going from `Array` to `ArrayView` is easy. The opposite direction requires a copy. Calling rust from R with `extendr` passes a view, so view everywhere for now.